### PR TITLE
Create and set NetworkData at load time

### DIFF
--- a/src/main/java/sonar/flux/FluxEvents.java
+++ b/src/main/java/sonar/flux/FluxEvents.java
@@ -49,24 +49,15 @@ public class FluxEvents {
 			return;
 		}
 		if (event.getWorld().provider.getDimension() == FluxNetworks.saveDimension) {
-			NetworkData data = (NetworkData) event.getWorld().getPerWorldStorage().getOrLoadData(NetworkData.class, NetworkData.tag);
-			if (data != null) {
-				data.loadAllNetworks();
-				data.clearLoadedNetworks();
-			}
-		}
-	}
-
-	@SubscribeEvent
-	public void onWorldSave(WorldEvent.Save event) {
-		if (event.getWorld().isRemote) {
-			return;
-		}
-		if (event.getWorld().provider.getDimension() == FluxNetworks.saveDimension) {
 			MapStorage storage = event.getWorld().getPerWorldStorage();
 			NetworkData data = (NetworkData) storage.getOrLoadData(NetworkData.class, NetworkData.tag);
-			if (data == null && !FluxNetworks.getServerCache().getAllNetworks().isEmpty()) {
+			if (data == null) {
 				storage.setData(NetworkData.tag, new NetworkData(NetworkData.tag));
+			}
+			else
+			{
+				data.loadAllNetworks();
+				data.clearLoadedNetworks();
 			}
 		}
 	}


### PR DESCRIPTION
Create and set a NetworkData instance at world load time so it is guaranteed to exist when a world's data is flushed to disk.
Previously, a new instance was only created during a WorldEvent.Save event, which occurs after a world's data is flushed to disk, therefore meaning the data was not actually saved if the server then shut down.
This also means the WorldEvent.Save handler should no longer be necessary.
Should fix #178