### PR TITLE
Adjust loading and saving (again)

### DIFF
--- a/src/main/java/sonar/flux/FluxEvents.java
+++ b/src/main/java/sonar/flux/FluxEvents.java
@@ -6,13 +6,10 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.world.storage.MapStorage;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.world.BlockEvent.HarvestDropsEvent;
-import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
@@ -22,10 +19,8 @@ import sonar.flux.api.FluxListener;
 import sonar.flux.api.network.IFluxNetwork;
 import sonar.flux.common.entity.EntityFireItem;
 import sonar.flux.network.FluxNetworkCache;
-import sonar.flux.network.NetworkData;
 
 public class FluxEvents {
-
 	@SubscribeEvent
 	public void onServerTick(TickEvent.ServerTickEvent event) {
 		if (event.side == Side.CLIENT) {
@@ -42,30 +37,7 @@ public class FluxEvents {
 			}
 		}
 	}
-
-	@SubscribeEvent
-	public void onWorldLoad(WorldEvent.Load event) {
-		if (event.getWorld().isRemote) {
-			return;
-		}
-		MapStorage storage = event.getWorld().getMapStorage();
-		NetworkData data = (NetworkData) storage.getOrLoadData(NetworkData.class, NetworkData.tag);
-		if (data == null) {
-			/// for recovering data previously saved in perWorldStorage - this should be left in until at least 1.13
-			NetworkData old_data = (NetworkData) event.getWorld().getPerWorldStorage().getOrLoadData(NetworkData.class, NetworkData.tag);
-			if (old_data != null) {
-				old_data.loadAllNetworks();
-				old_data.clearLoadedNetworks();	
-				storage.setData(NetworkData.tag, new NetworkData(NetworkData.tag));
-			} else {
-				storage.setData(NetworkData.tag, new NetworkData(NetworkData.tag));
-			}
-		} else {
-			data.loadAllNetworks();
-			data.clearLoadedNetworks();
-		}
-	}
-
+	
 	@SubscribeEvent
 	public void dropFluxEvent(HarvestDropsEvent drops) {
 		if (!FluxConfig.enableFluxRedstoneDrop || !(drops.getState().getBlock() == Blocks.REDSTONE_ORE || (drops.getState().getBlock() == Blocks.LIT_REDSTONE_ORE)) || drops.getHarvester() instanceof FakePlayer || drops.isSilkTouching()) {
@@ -74,7 +46,6 @@ public class FluxEvents {
 		if (SonarCore.randInt(0, FluxConfig.redstone_ore_chance) == 1) {
 			drops.getDrops().add(new ItemStack(FluxNetworks.flux, Math.max(1, SonarCore.randInt(FluxConfig.redstone_ore_min_drop, FluxConfig.redstone_ore_max_drop))));
 		}
-
 	}
 
 	@SubscribeEvent
@@ -86,7 +57,6 @@ public class FluxEvents {
 		if (entity instanceof EntityItem && !(entity instanceof EntityFireItem)) {
 			EntityItem entityItem = (EntityItem) entity;
 			ItemStack stack = entityItem.getItem();
-			Item item;
 			if (!stack.isEmpty() && stack.getItem() == Items.REDSTONE) {
 				EntityFireItem newEntity = new EntityFireItem(event.getWorld(), entityItem.posX, entityItem.posY, entityItem.posZ, stack);
 				newEntity.motionX = entityItem.motionX;

--- a/src/main/java/sonar/flux/FluxNetworks.java
+++ b/src/main/java/sonar/flux/FluxNetworks.java
@@ -11,6 +11,8 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.MapStorage;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -19,6 +21,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.event.FMLServerStoppedEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
@@ -44,6 +47,7 @@ import sonar.flux.connection.FluxHelper;
 import sonar.flux.network.ClientNetworkCache;
 import sonar.flux.network.FluxCommon;
 import sonar.flux.network.FluxNetworkCache;
+import sonar.flux.network.NetworkData;
 
 @Mod(modid = FluxNetworks.modid, name = FluxNetworks.name, acceptedMinecraftVersions = FluxNetworks.mc_versions, version = FluxNetworks.version, dependencies = "required-after:sonarcore@[" + FluxNetworks.SONAR_VERSION + ",);")
 public class FluxNetworks {
@@ -155,8 +159,16 @@ public class FluxNetworks {
 		FluxNetworks.energyContainerHandlers = FluxHelper.getEnergyContainerHandlers();
 	}
 
+    @EventHandler
+    public void onServerStarting(FMLServerStartingEvent event) {
+        MapStorage storage = DimensionManager.getWorld(0).getMapStorage();
+        if(storage.getOrLoadData(NetworkData.class, NetworkData.IDENTIFIER) == null) {
+            storage.setData(NetworkData.IDENTIFIER, new NetworkData());
+        }
+    }
+    
 	@EventHandler
-	public void onServerStopping(FMLServerStoppedEvent event) {
+	public void onServerStopped(FMLServerStoppedEvent event) {
 		serverCache.clearNetworks();
 		clientCache.clearNetworks();
 		logger.info("Cleared Network Caches");

--- a/src/main/java/sonar/flux/network/FluxNetworkCache.java
+++ b/src/main/java/sonar/flux/network/FluxNetworkCache.java
@@ -27,7 +27,7 @@ import sonar.flux.connection.FluxHelper;
 
 /** all the flux networks are created/stored/deleted here, an instance is found via the FluxAPI */
 public class FluxNetworkCache implements IFluxNetworkCache, ISonarListenable<PlayerListener> {
-	public ListenableList<PlayerListener> listeners = new ListenableList(this, FluxListener.values().length);
+	public ListenableList<PlayerListener> listeners = new ListenableList<>(this, FluxListener.values().length);
 	public ConcurrentHashMap<UUID, ArrayList<IFluxNetwork>> networks = new ConcurrentHashMap<>();
 
 	public int uniqueID = 1;

--- a/src/main/java/sonar/flux/network/NetworkData.java
+++ b/src/main/java/sonar/flux/network/NetworkData.java
@@ -1,9 +1,6 @@
 package sonar.flux.network;
 
-import java.util.List;
 import java.util.UUID;
-
-import com.google.common.collect.Lists;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -20,7 +17,7 @@ import sonar.flux.connection.BasicFluxNetwork;
 
 public class NetworkData extends WorldSavedData {
 
-	public static final String tag = "sonar.flux.networks.configurations";
+	public static final String IDENTIFIER = "sonar.flux.networks.configurations";
 	public static String TAG_LIST = "networks";
 	public static String UNIQUE_ID = "uniqueID";
 	public static String NETWORK_ID = "id";
@@ -30,26 +27,19 @@ public class NetworkData extends WorldSavedData {
 	public static String NETWORK_NAME = "name";
 	public static String ACCESS = "access";
 	public static String PLAYER_LIST = "playerList";
-	public List<IFluxNetwork> loaded = Lists.newArrayList();
 
-	public NetworkData(String name) {
-		super(name);
-	}
+    public NetworkData(String name) {
+        super(name);
+    }
 
-	public void loadAllNetworks() {
-		loaded.forEach(network -> {
-			FluxNetworks.getServerCache().addNetwork(network);
-			FluxEvents.logLoadedNetwork(network);
-		});
-	}
-
-	public void clearLoadedNetworks() {
-		loaded.clear();
+	public NetworkData() {
+		this(IDENTIFIER);
 	}
 
 	@Override
 	public void readFromNBT(NBTTagCompound nbt) {
-		FluxNetworks.getServerCache().uniqueID = nbt.getInteger(UNIQUE_ID);
+	    FluxNetworkCache cache = FluxNetworks.getServerCache();
+		cache.uniqueID = nbt.getInteger(UNIQUE_ID);
 		if (nbt.hasKey(TAG_LIST)) {
 			NBTTagList list = nbt.getTagList(TAG_LIST, NBT.TAG_COMPOUND);
 			for (int i = 0; i < list.tagCount(); i++) {
@@ -62,34 +52,37 @@ public class NetworkData extends WorldSavedData {
 				AccessType type = AccessType.valueOf(tag.getString(ACCESS));
 				BasicFluxNetwork network = new BasicFluxNetwork(networkID, ownerUUID, networkName, colour, type);
 				network.getPlayers().readData(tag.getCompoundTag(PLAYER_LIST), SyncType.SAVE);
-				loaded.add(network);
+				cache.addNetwork(network);
+				FluxEvents.logLoadedNetwork(network);
 			}
 		}
 	}
 
 	@Override
 	public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-		nbt.setInteger(UNIQUE_ID, FluxNetworks.getServerCache().uniqueID);
-		NBTTagList list = new NBTTagList();
-		for (IFluxNetwork network : FluxNetworks.getServerCache().getAllNetworks()) {
-			NBTTagCompound tag = new NBTTagCompound();
-			tag.setInteger(NETWORK_ID, network.getNetworkID());
-			tag.setUniqueId(OWNER_UUID, network.getOwnerUUID());
-			tag.setString(CACHE_PLAYER, network.getCachedPlayerName());
-			tag.setString(NETWORK_NAME, network.getNetworkName());
-			tag.setTag(COLOUR, network.getNetworkColour().writeData(new NBTTagCompound(), SyncType.SAVE));
-			tag.setString(ACCESS, network.getAccessType().name());
-			tag.setTag(PLAYER_LIST, network.getPlayers().writeData(new NBTTagCompound(), SyncType.SAVE));
-			list.appendTag(tag);
-		}
-		if (!list.hasNoTags()) {
-			nbt.setTag(TAG_LIST, list);
-			FluxNetworks.logger.debug("ALL " + list.tagCount() + " Networks were saved successfully");
+        FluxNetworkCache cache = FluxNetworks.getServerCache();
+		nbt.setInteger(UNIQUE_ID, cache.uniqueID);
+		if(cache.getAllNetworks().size() > 0)
+		{
+    		NBTTagList list = new NBTTagList();
+    		for (IFluxNetwork network : FluxNetworks.getServerCache().getAllNetworks()) {
+    			NBTTagCompound tag = new NBTTagCompound();
+    			tag.setInteger(NETWORK_ID, network.getNetworkID());
+    			tag.setUniqueId(OWNER_UUID, network.getOwnerUUID());
+    			tag.setString(CACHE_PLAYER, network.getCachedPlayerName());
+    			tag.setString(NETWORK_NAME, network.getNetworkName());
+    			tag.setTag(COLOUR, network.getNetworkColour().writeData(new NBTTagCompound(), SyncType.SAVE));
+    			tag.setString(ACCESS, network.getAccessType().name());
+    			tag.setTag(PLAYER_LIST, network.getPlayers().writeData(new NBTTagCompound(), SyncType.SAVE));
+    			list.appendTag(tag);
+    		}
+    		nbt.setTag(TAG_LIST, list);
+    		FluxNetworks.logger.debug("ALL " + list.tagCount() + " Networks were saved successfully");
 		}
 		return nbt;
 	}
 
 	public boolean isDirty() {
-		return true;//!FluxNetworks.getServerCache().getAllNetworks().isEmpty();
+		return true;
 	}
 }


### PR DESCRIPTION
Use ServerStartingEvent to create and/or load NetworkData. Add networks to server cache in NetworkData#readFromNBT as opposed to loading from NBT, caching to a list, loading into the server cache, then clearing the list. Also, since the overworld's perWorldStorage is the same as its mapStorage, handling the loading of 'old' saving mechanisms shouldn't be necessary.

I think it will be safer overall to do it this way, so there's no edge cases of something loading twice, or getting cleared after being loaded. Plus, there's no need for the backwards-compatibility thing either way - it's still saving in the same place, in the same format.