### PR TITLE
Fixes #197

### DIFF
--- a/src/main/java/sonar/flux/FluxEvents.java
+++ b/src/main/java/sonar/flux/FluxEvents.java
@@ -68,10 +68,16 @@ public class FluxEvents {
 				newEntity.motionY = entityItem.motionY;
 				newEntity.motionZ = entityItem.motionZ;
 				newEntity.setDefaultPickupDelay();
+				newEntity.setThrower(entityItem.getThrower());
 				if (newEntity != null) {
 					event.getEntity().setDead();
 					// event.setCanceled(true) fixes duping but causes "Fetching addPacket for removed entity" warning on each Redstone/EnderEye Drop
 					event.getWorld().spawnEntity(newEntity);
+					if(entityItem.getThrower()!= null) {
+						EntityPlayer player = FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getPlayerByUsername(entityItem.getThrower());
+						ItemTossEvent e = new ItemTossEvent(newEntity, player);
+						MinecraftForge.EVENT_BUS.post(e);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Adds such that mods that uses the EntityJoinWorldEvent to look for items being thrown is not affected by the switch to EntityFireItem.
Fires a new ItemToss event if the item being converted to a EntityFireItem has been thrown by a player, such that mods that uses the ItemTossEvent is not affected.