### PR TITLE
Add basic support for computercraft / cc:tweaked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,12 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        url "https://squiddev.cc/maven/"
+        content {
+            includeGroup("cc.tweaked")
+        }
+    }
     mavenCentral()
 }
 
@@ -151,6 +157,10 @@ dependencies {
         exclude group: "it.unimi.dsi", module: "fastutil"
     }
     implementation fg.deobf("icyllis.modernui:ModernUI-Forge:${minecraft_version}-${modernui_forge_version}")
+
+    compileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-core-api:1.110.3")
+    compileOnly(fg.deobf("cc.tweaked:cc-tweaked-${minecraft_version}-forge-api:1.110.3"))
+    runtimeOnly(fg.deobf("cc.tweaked:cc-tweaked-${minecraft_version}-forge:1.110.3"))
 }
 
 processResources {

--- a/src/main/java/sonar/fluxnetworks/FluxNetworks.java
+++ b/src/main/java/sonar/fluxnetworks/FluxNetworks.java
@@ -5,6 +5,7 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import sonar.fluxnetworks.common.integration.cctweaked.PeripheralHandlerWrapper;
 
 import javax.annotation.Nonnull;
 
@@ -19,12 +20,17 @@ public class FluxNetworks {
 
     private static boolean sCuriosLoaded;
     private static boolean sModernUILoaded;
+    private static boolean sComputercraftLoaded;
 
     public FluxNetworks() {
         sCuriosLoaded = ModList.get().isLoaded("curios");
         sModernUILoaded = ModList.get().isLoaded("modernui");
+        sComputercraftLoaded = ModList.get().isLoaded("computercraft");
 
         FluxConfig.init();
+
+        if (sComputercraftLoaded)
+            PeripheralHandlerWrapper.init();
     }
 
     public static boolean isCuriosLoaded() {
@@ -33,6 +39,9 @@ public class FluxNetworks {
 
     public static boolean isModernUILoaded() {
         return sModernUILoaded;
+    }
+    public static boolean issComputercraftLoaded() {
+        return sComputercraftLoaded;
     }
 
     @Nonnull

--- a/src/main/java/sonar/fluxnetworks/common/device/TileFluxController.java
+++ b/src/main/java/sonar/fluxnetworks/common/device/TileFluxController.java
@@ -1,19 +1,10 @@
 package sonar.fluxnetworks.common.device;
 
-import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ForgeCapabilities;
-import net.minecraftforge.common.util.LazyOptional;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import sonar.fluxnetworks.api.FluxCapabilities;
 import sonar.fluxnetworks.api.device.FluxDeviceType;
 import sonar.fluxnetworks.api.device.IFluxController;
-import sonar.fluxnetworks.common.integration.cctweaked.CCTPeripheral;
 import sonar.fluxnetworks.common.util.FluxGuiStack;
 import sonar.fluxnetworks.register.RegistryBlockEntityTypes;
 
@@ -44,5 +35,4 @@ public class TileFluxController extends TileFluxDevice implements IFluxControlle
     public ItemStack getDisplayStack() {
         return FluxGuiStack.FLUX_CONTROLLER;
     }
-
 }

--- a/src/main/java/sonar/fluxnetworks/common/device/TileFluxController.java
+++ b/src/main/java/sonar/fluxnetworks/common/device/TileFluxController.java
@@ -1,10 +1,19 @@
 package sonar.fluxnetworks.common.device;
 
+import dan200.computercraft.api.peripheral.IPeripheral;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ForgeCapabilities;
+import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import sonar.fluxnetworks.api.FluxCapabilities;
 import sonar.fluxnetworks.api.device.FluxDeviceType;
 import sonar.fluxnetworks.api.device.IFluxController;
+import sonar.fluxnetworks.common.integration.cctweaked.CCTPeripheral;
 import sonar.fluxnetworks.common.util.FluxGuiStack;
 import sonar.fluxnetworks.register.RegistryBlockEntityTypes;
 
@@ -35,4 +44,5 @@ public class TileFluxController extends TileFluxDevice implements IFluxControlle
     public ItemStack getDisplayStack() {
         return FluxGuiStack.FLUX_CONTROLLER;
     }
+
 }

--- a/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/CCTPeripheral.java
+++ b/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/CCTPeripheral.java
@@ -1,0 +1,184 @@
+package sonar.fluxnetworks.common.integration.cctweaked;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.lua.ObjectLuaTable;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import org.jetbrains.annotations.Nullable;
+import sonar.fluxnetworks.api.device.IFluxDevice;
+import sonar.fluxnetworks.common.device.TileFluxDevice;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class CCTPeripheral implements IPeripheral {
+
+    record NetworkMemberRecord(String name, String accessLevel) {
+    }
+
+    record NetworkDeviceRecord(
+            String type,
+            long maxTransferLimit,
+            boolean isChunkLoaded,
+
+            boolean isForcedChunkLoaded,
+            String customName,
+            boolean limitDisabled,
+
+            Map<String, Object> position,
+            boolean surgeMode,
+            long transferBuffer,
+            long transferChange
+    ) {}
+
+    private final TileFluxDevice device;
+
+    public CCTPeripheral(TileFluxDevice device) {
+        this.device = device;
+    }
+
+    @Override
+    public String getType() {
+        return "flux-device";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral other) {
+        return false;
+    }
+
+    @LuaFunction(mainThread = true)
+    public String getNetworkName() {
+        if (!isValid()) return null;
+
+        String name = device.getNetwork().getNetworkName();
+        if (name.isEmpty())
+            return null;
+        return name;
+    }
+
+    private Map<String, Object> objectToMap(Object object) {
+        Map<String, Object> map = new HashMap<>();
+        Field[] fields = object.getClass().getDeclaredFields();
+
+        for (Field field: fields) {
+            field.setAccessible(true);
+            try {
+                map.put(field.getName(), field.get(object));
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return map;
+    }
+
+    @LuaFunction(mainThread = true)
+    public int getNetworkID() {
+        return device.getNetwork().getNetworkID();
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getEnergyInput() {
+        return device.getNetwork().getStatistics().energyInput;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getEnergyOutput() {
+        return device.getNetwork().getStatistics().energyOutput;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getEnergy() {
+        return device.getNetwork().getStatistics().totalEnergy;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getEnergyBuffer() {
+        return device.getNetwork().getStatistics().totalBuffer;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getPlugsCount() {
+        return device.getNetwork().getStatistics().fluxPlugCount;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getPointCount() {
+        return device.getNetwork().getStatistics().fluxPointCount;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getStorageCount() {
+        return device.getNetwork().getStatistics().fluxStorageCount;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getControllerCount() {
+        return device.getNetwork().getStatistics().fluxControllerCount;
+    }
+
+    @LuaFunction(mainThread = true)
+    public long getAVGTickUs() {
+        return device.getNetwork().getStatistics().averageTickMicro;
+    }
+
+    @LuaFunction(mainThread = true)
+    public String getSecurityLevel() {
+        return device.getNetwork().getSecurityLevel().toString();
+    }
+
+    @LuaFunction(mainThread = true)
+    public String getOwner() {
+        if (!isValid()) return null;
+
+        return device.getNetwork().getOwnerUUID().toString();
+    }
+
+    @LuaFunction(mainThread = true)
+    public ObjectLuaTable getMembers() {
+        if (!isValid()) return null;
+
+        return new ObjectLuaTable(
+                device.getNetwork().getAllMembers().stream().collect(Collectors.toMap(
+                        item -> item.getPlayerUUID().toString(),
+                        item -> objectToMap(new NetworkMemberRecord(item.getCachedName(), item.getAccessLevel().toString()))
+                )
+            )
+        );
+    }
+
+    @LuaFunction(mainThread = true)
+    public ObjectLuaTable getConnections() {
+        if (!isValid()) return null;
+
+        Map<Integer, Object> map = new HashMap<>();
+        int i = 0;
+        for (IFluxDevice device :  device.getNetwork().getAllConnections()) {
+            map.put(
+                    i++,
+                    objectToMap(
+                        new NetworkDeviceRecord(
+                                device.getDeviceType().toString(),
+                                device.getMaxTransferLimit(),
+                                device.isChunkLoaded(),
+                                device.isForcedLoading(),
+                                device.getCustomName(),
+                                device.getDisableLimit(),
+                                objectToMap(device.getGlobalPos()),
+                                device.getSurgeMode(),
+                                device.getTransferBuffer(),
+                                device.getTransferChange()
+                        )
+                    )
+            );
+        }
+
+        return new ObjectLuaTable(map);
+    }
+
+    @LuaFunction(mainThread = true)
+    public boolean isValid() {
+        return device.getNetwork().isValid();
+    }
+}

--- a/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/PeripheralHandler.java
+++ b/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/PeripheralHandler.java
@@ -1,0 +1,22 @@
+package sonar.fluxnetworks.common.integration.cctweaked;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.util.LazyOptional;
+import sonar.fluxnetworks.common.device.TileFluxController;
+import sonar.fluxnetworks.common.device.TileFluxDevice;
+
+public class PeripheralHandler implements IPeripheralProvider {
+
+    @Override
+    public LazyOptional<IPeripheral> getPeripheral(Level world, BlockPos pos, Direction side) {
+        BlockEntity tile = world.getBlockEntity(pos);
+
+        if (tile instanceof TileFluxDevice fluxDevice) return LazyOptional.of(() -> new CCTPeripheral(fluxDevice));
+        return null;
+    }
+}

--- a/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/PeripheralHandler.java
+++ b/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/PeripheralHandler.java
@@ -17,6 +17,6 @@ public class PeripheralHandler implements IPeripheralProvider {
         BlockEntity tile = world.getBlockEntity(pos);
 
         if (tile instanceof TileFluxDevice fluxDevice) return LazyOptional.of(() -> new CCTPeripheral(fluxDevice));
-        return null;
+        return LazyOptional.empty();
     }
 }

--- a/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/PeripheralHandlerWrapper.java
+++ b/src/main/java/sonar/fluxnetworks/common/integration/cctweaked/PeripheralHandlerWrapper.java
@@ -1,0 +1,16 @@
+package sonar.fluxnetworks.common.integration.cctweaked;
+
+import dan200.computercraft.api.ForgeComputerCraftAPI;
+
+/**
+ * This class exists, so we do not import PeripheralHandler directly into the FluxNetworks class
+ * as PeripheralHandler implements a computercraft class. This would break if the computercraft mod
+ * is not available
+ */
+public class PeripheralHandlerWrapper {
+
+    public static void init() {
+        ForgeComputerCraftAPI.registerPeripheralProvider(new PeripheralHandler());
+    }
+
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -32,6 +32,12 @@ license="MIT"
     ordering="NONE"
     side="BOTH"
 [[dependencies.fluxnetworks]]
+    modId="computercraft"
+    mandatory=false
+    versionRange="[1.110.3,)"
+    ordering="NONE"
+    side="BOTH"
+[[dependencies.fluxnetworks]]
     modId="jei"
     mandatory=false
     versionRange="[14,)"


### PR DESCRIPTION
This PR adds basic support for Computercraft

My version of the mod is already being used on a personnal server everything looks fine.
My changes to the core mod are minimal, the only thing to double check would be:
- Computercraft / cc tweaked version
- How Flux Networks behaves when cc tweaked is not present

This pr will add all the following functions
![image](https://github.com/SonarSonic/Flux-Networks/assets/3948904/8082bdc3-a55f-41a2-86de-ba755db6b73d)

to all the following blocks:

- Flux controller
- All Flux storage
- Flux port
- Plux point