### PR TITLE
1.12.2 refactored HBMEE Item Only Compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     compileOnly fg.deobf("curse.maven:industrial-craft-242638:2746894")
     compileOnly fg.deobf("curse.maven:mekanism-268560:2835176")
     compileOnly fg.deobf("curse.maven:redstone-flux-270789:2920436")
+    compileOnly fg.deobf("curse.maven:hbm-nuclear-tech-extended-edition-708939:5254559")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 minecraft_version=1.12.2
 forge_version=14.23.5.2854
-mod_version=4.1.1.34
+mod_version=4.1.1.35-HBMEE-Compat
 
 jei_version=4.16.1.302
 top_version=1.12-1.4.28-17

--- a/src/main/java/sonar/fluxnetworks/common/handler/TileEntityHandler.java
+++ b/src/main/java/sonar/fluxnetworks/common/handler/TileEntityHandler.java
@@ -3,10 +3,7 @@ package sonar.fluxnetworks.common.handler;
 import com.google.common.collect.Lists;
 import sonar.fluxnetworks.api.energy.ITileEnergyHandler;
 import sonar.fluxnetworks.api.tiles.IFluxConnector;
-import sonar.fluxnetworks.common.integration.energy.ForgeEnergyHandler;
-import sonar.fluxnetworks.common.integration.energy.GTEnergyHandler;
-import sonar.fluxnetworks.common.integration.energy.IC2EnergyHandler;
-import sonar.fluxnetworks.common.integration.energy.RedstoneFluxHandler;
+import sonar.fluxnetworks.common.integration.energy.*;
 import sonar.fluxnetworks.common.tileentity.TileFluxController;
 import sonar.fluxnetworks.common.tileentity.TileFluxPlug;
 import sonar.fluxnetworks.common.tileentity.TileFluxPoint;
@@ -57,6 +54,9 @@ public class TileEntityHandler {
         if(Loader.isModLoaded("ic2")) {
             tileEnergyHandlers.add(IC2EnergyHandler.INSTANCE);
             ItemEnergyHandler.itemEnergyHandlers.add(IC2EnergyHandler.INSTANCE);
+        }
+        if(Loader.isModLoaded("hbm")) {
+            ItemEnergyHandler.itemEnergyHandlers.add(HBMEnergyHandler.INSTANCE);
         }
     }
 

--- a/src/main/java/sonar/fluxnetworks/common/integration/energy/HBMEnergyHandler.java
+++ b/src/main/java/sonar/fluxnetworks/common/integration/energy/HBMEnergyHandler.java
@@ -1,0 +1,98 @@
+package sonar.fluxnetworks.common.integration.energy;
+
+import api.hbm.energy.IBatteryItem;
+import com.hbm.capability.HbmCapability;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.IEnergyStorage;
+import sonar.fluxnetworks.api.energy.IItemEnergyHandler;
+import sonar.fluxnetworks.api.energy.ITileEnergyHandler;
+
+import javax.annotation.Nonnull;
+
+public class HBMEnergyHandler implements ITileEnergyHandler, IItemEnergyHandler {
+
+    public static final HBMEnergyHandler INSTANCE = new HBMEnergyHandler();
+
+    private HBMEnergyHandler() {
+    }
+
+    @Override
+    public boolean hasCapability(@Nonnull TileEntity tile, EnumFacing side) {
+        return false;
+    }
+
+    @Override
+    public boolean canAddEnergy(@Nonnull TileEntity tile, EnumFacing side) {
+        return false;
+    }
+
+    @Override
+    public boolean canRemoveEnergy(@Nonnull TileEntity tile, EnumFacing side) {
+        return false;
+    }
+
+    @Override
+    public long addEnergy(long amount, @Nonnull TileEntity tile, EnumFacing side, boolean simulate) {
+        return 0;
+    }
+
+    @Override
+    public long removeEnergy(long amount, @Nonnull TileEntity tile, EnumFacing side) {
+        return 0;
+    }
+
+    @Override
+    public boolean hasCapability(@Nonnull ItemStack stack) {
+        return IBatteryItem.class.isAssignableFrom(stack.getItem().getClass());
+    }
+
+    @Override
+    public boolean canAddEnergy(@Nonnull ItemStack stack) {
+        if(IBatteryItem.class.isAssignableFrom(stack.getItem().getClass())) {
+            IBatteryItem batteryItem = (IBatteryItem) stack.getItem();
+            return batteryItem.getCharge(stack) < batteryItem.getMaxCharge();
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canRemoveEnergy(@Nonnull ItemStack stack) {
+        return false;
+    }
+
+    //note that this should return the amount of energy transfered to the item
+    @Override
+    public long addEnergy(long amount, @Nonnull ItemStack stack, boolean simulate) {
+        if(IBatteryItem.class.isAssignableFrom(stack.getItem().getClass())) {
+            //System.out.println("Attempting to charge: " + stack + " simulate: " + simulate);
+            IBatteryItem batteryItem = (IBatteryItem) stack.getItem();
+            if (batteryItem.getMaxCharge() <= batteryItem.getCharge(stack)) {
+                //System.out.println("max charge for: " + stack);
+            } else {
+                long missingCharge = batteryItem.getMaxCharge() - batteryItem.getCharge(stack);
+                if (missingCharge <= amount) {
+                    if (!simulate) {
+                        batteryItem.chargeBattery(stack, missingCharge);
+                    }
+                    //System.out.println("1: " + amount + " : " + batteryItem.getCharge(stack));
+                    return missingCharge;
+                } else {//missingCharge > amount
+                    if (!simulate) {
+                        batteryItem.chargeBattery(stack, amount);
+                    }
+                    //System.out.println("2: " + amount + " : " + batteryItem.getCharge(stack));
+                    return amount;
+                }
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public long removeEnergy(long amount, @Nonnull ItemStack stack) {
+        return 0;
+    }
+}


### PR DESCRIPTION
This adds compatability for flux networks to charge HBMEE Items.

NOTE: I have not added support for Tiles in this pull request, mostly because im personally not interested in it. I just want the QOL for armor charging tbh.

NOTE2: This does not obey HBMEE's RF-HE conversion ratio config, mostly just cus im running 1-1 (the default) anyway and im lazy.