### PR TITLE
[1.21] Fix buildscript

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,8 +142,8 @@ sourceSets.main.configure {
 // This configuration should be used instead of 'runtimeOnly' to declare
 // a dependency that will be present for runtime testing but that is
 // "optional", meaning it will not be pulled by dependents of this mod.
-val localRuntime = configurations.register("localRuntime") {
-    extendsFrom(configurations.runtimeOnly.get())
+val localRuntime = configurations.create("localRuntime") {
+    configurations.getByName("runtimeClasspath").extendsFrom(this)
 }
 
 dependencies {
@@ -179,14 +179,14 @@ dependencies {
         exclude("com.ibm.icu", "icu4j")
         exclude("it.unimi.dsi", "fastutil")
     }
-    implementation("icyllis.modernui:ModernUI-Core:${"deps.modernui_core"()}") {
+    additionalRuntimeClasspath(compileOnly("icyllis.modernui:ModernUI-Core:${"deps.modernui_core"()}") {
         exclude("org.apache.logging.log4j", "log4j-core")
         exclude("org.apache.logging.log4j", "log4j-api")
         exclude("com.google.code.findbugs", "jsr305")
         exclude("org.jetbrains", "annotations")
         exclude("com.ibm.icu", "icu4j")
         exclude("it.unimi.dsi", "fastutil")
-    }
+    })
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.


### PR DESCRIPTION
Fixed an issue where the debug environment could not be launched.  

The following are the causes of this issue and their respective solutions:
- Incorrect definition of `localRuntime`
  - Updated to a definition faithful to the one in MDK.  
- External libraries not being loaded  
  - Modified to load them in accordance with the ModDevGradle documentation.
