### PR TITLE
added comparator support to FluxStorageBlock

### DIFF
--- a/src/main/java/sonar/fluxnetworks/common/block/FluxStorageBlock.java
+++ b/src/main/java/sonar/fluxnetworks/common/block/FluxStorageBlock.java
@@ -35,6 +35,20 @@ public abstract class FluxStorageBlock extends FluxDeviceBlock {
         tooltip.add(FluxTranslate.FLUX_STORAGE_TOOLTIP_2.makeComponent(EnergyType.FE.getStorage(getEnergyCapacity())));
     }
 
+    @Override
+    public boolean hasAnalogOutputSignal(BlockState state) {
+        return true;
+    }
+
+    @Override
+    public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
+        if (level.getBlockEntity(pos) instanceof TileFluxStorage storage) {
+            double fillRatio = (double) storage.getTransferBuffer() / storage.getMaxTransferLimit();
+            return Math.max(0, Math.min(15, (int) (fillRatio * 15.0)));
+        }
+        return 0;
+    }
+
     public abstract long getEnergyCapacity();
 
     public static class Basic extends FluxStorageBlock {

--- a/src/main/java/sonar/fluxnetworks/common/device/TileFluxStorage.java
+++ b/src/main/java/sonar/fluxnetworks/common/device/TileFluxStorage.java
@@ -84,6 +84,7 @@ public abstract class TileFluxStorage extends TileFluxDevice implements IFluxSto
                 Channel.get().sendToTrackingChunk(
                         Messages.makeDeviceBuffer(this, FluxConstants.DEVICE_S2C_STORAGE_ENERGY),
                         level.getChunkAt(worldPosition));
+                level.updateNeighbourForOutputSignal(worldPosition, getBlockState().getBlock());
                 mFlags &= ~FLAG_ENERGY_CHANGED;
             }
         }


### PR DESCRIPTION
This is my second public PR!

When using this mod I found that it could be useful to be able to read the FluxStorageBlock's current buffer as a redstone signal to control the base's main power source. I opted to use a comparator here but would be open to changing the actual method.